### PR TITLE
just upgrade everything

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,16 +7,16 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 steps:
-- task: NodeTool@0
-  inputs:
-    versionSpec: '8.x'
-  displayName: 'Install Node.js'
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.x'
+    displayName: 'Install Node.js'
 
-- task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
-  inputs:
-    versionSpec: '1.9.4'
+  - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@2
+    inputs:
+      versionSpec: '1.9.4'
 
-- script: |
-    npm install
-    ./node_modules/.bin/tsc
-  displayName: 'npm install and compile'
+  - script: |
+      yarn install
+      ./node_modules/.bin/tsc
+    displayName: 'yarn install and compile'

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,12 +8,15 @@ function delay(ms: number): Promise<void> {
   })
 }
 
-type Comment = {
+export interface User {
+  readonly login: string
+}
+
+export interface Comment {
+  readonly created_at: string
   readonly updated_at: string
   readonly body: string
-  readonly user: {
-    readonly login: string
-  }
+  readonly user: User
 }
 
 const per_page = 100

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,39 +8,12 @@ function delay(ms: number): Promise<void> {
   })
 }
 
-export interface User {
-  readonly login: string
-}
-
-export interface PullRequest {
-  readonly number: number
-  readonly title: string
-  readonly user: User
-  readonly assignee: User | null
+type Comment = {
   readonly updated_at: string
-  readonly mergeable: boolean | null
-}
-
-export interface Comment {
   readonly body: string
-  readonly user: User
-  readonly created_at: string
-  readonly updated_at: string
-}
-
-export interface Commit {
-  readonly author: User | null
-  readonly committer: User | null
-}
-
-export interface PullRequestReview {
-  readonly user: User
-  readonly state: 'COMMENTED' | 'APPROVED' | 'CHANGES_REQUESTED'
-  readonly submitted_at: string
-}
-
-interface OctokitResponse<T> {
-  readonly data: T
+  readonly user: {
+    readonly login: string
+  }
 }
 
 const per_page = 100
@@ -59,18 +32,16 @@ export class GitHubClient {
     })
   }
 
-  public getUser = async (): Promise<User> => {
-    const user: OctokitResponse<User> = await this.client.users.get({})
+  public getUser = async () => {
+    const user = await this.client.users.get({})
     return user.data
   }
 
   public getOpenPullRequests = async (
     sort: 'created' | 'updated' | 'popularity' | 'long-running' = 'updated',
     direction: 'asc' | 'desc' = 'asc'
-  ): Promise<ReadonlyArray<PullRequest>> => {
-    const result: OctokitResponse<
-      Array<PullRequest>
-    > = await this.client.pullRequests.getAll({
+  ) => {
+    const result = await this.client.pullRequests.getAll({
       owner: this.owner,
       repo: this.repo,
       state: 'open',
@@ -81,10 +52,8 @@ export class GitHubClient {
     return result.data
   }
 
-  public getPullRequest = async (number: number): Promise<PullRequest> => {
-    const result: OctokitResponse<
-      PullRequest
-    > = await this.client.pullRequests.get({
+  public getPullRequest = async (number: number) => {
+    const result = await this.client.pullRequests.get({
       owner: this.owner,
       repo: this.repo,
       number,
@@ -92,13 +61,8 @@ export class GitHubClient {
     return result.data
   }
 
-  public getLastPullRequestComment = async (
-    number: number,
-    login: string
-  ): Promise<Comment | null> => {
-    const pullRequestComments: OctokitResponse<
-      Array<Comment>
-    > = await this.client.pullRequests.getComments({
+  public getLastPullRequestComment = async (number: number, login: string) => {
+    const pullRequestComments = await this.client.pullRequests.getComments({
       owner: this.owner,
       repo: this.repo,
       number,
@@ -119,28 +83,18 @@ export class GitHubClient {
     return lastPRComment
   }
 
-  public getReviewsFor = async (
-    pr: PullRequest
-  ): Promise<ReadonlyArray<PullRequestReview>> => {
-    const result: OctokitResponse<
-      Array<PullRequestReview>
-    > = await this.client.pullRequests.getReviews({
+  public getReviewsFor = async (pr: { number: number }) => {
+    const result = await this.client.pullRequests.getReviews({
       owner: this.owner,
       repo: this.repo,
       number: pr.number,
       per_page,
     })
-
     return result.data
   }
 
-  public getLastIssueComment = async (
-    number: number,
-    login: string
-  ): Promise<Comment | null> => {
-    const issueComments: OctokitResponse<
-      Array<Comment>
-    > = await this.client.issues.getComments({
+  public getLastIssueComment = async (number: number, login: string) => {
+    const issueComments = await this.client.issues.getComments({
       owner: this.owner,
       repo: this.repo,
       number,
@@ -162,10 +116,10 @@ export class GitHubClient {
   }
 
   public getLatestCommentBy = async (
-    pr: PullRequest,
+    pr: { number: number },
     login: string,
     debug: boolean = false
-  ): Promise<Comment | null> => {
+  ) => {
     const lastPRComment = await this.getLastPullRequestComment(pr.number, login)
     const lastIssueComment = await this.getLastIssueComment(pr.number, login)
 
@@ -219,13 +173,8 @@ export class GitHubClient {
     return null
   }
 
-  public getCommitsBy = async (
-    pr: PullRequest,
-    login: string
-  ): Promise<ReadonlyArray<Commit>> => {
-    const result: OctokitResponse<
-      Array<Commit>
-    > = await this.client.pullRequests.getCommits({
+  public getCommitsBy = async (pr: { number: number }, login: string) => {
+    const result = await this.client.pullRequests.getCommits({
       owner: this.owner,
       repo: this.repo,
       number: pr.number,

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "review-queue": "ts-node script/review-queue.ts"
   },
   "dependencies": {
-    "@octokit/rest": "^15.6.2",
+    "@octokit/rest": "^15.11.4",
     "chalk": "^2.4.1",
-    "moment": "^2.22.1",
-    "ts-node": "^6.0.3",
-    "typescript": "^2.8.3"
+    "moment": "^2.22.2",
+    "ts-node": "^7.0.1",
+    "typescript": "^3.0.3"
   },
   "devDependencies": {
-    "@types/node": "^10.1.2",
-    "prettier": "^1.12.1"
+    "@types/node": "^10.10.1",
+    "prettier": "^1.14.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@octokit/rest@^15.6.2":
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-15.6.2.tgz#e5f6836f6100098244921cf29bed322fc7d607c2"
+"@octokit/rest@^15.11.4":
+  version "15.11.4"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-15.11.4.tgz#0504134f3ba8e70615a27b9270963d575ab00087"
   dependencies:
     before-after-hook "^1.1.0"
     btoa-lite "^1.0.0"
@@ -15,9 +15,9 @@
     node-fetch "^2.1.1"
     url-template "^2.0.8"
 
-"@types/node@^10.1.2":
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.2.tgz#1b928a0baa408fc8ae3ac012cc81375addc147c6"
+"@types/node@^10.10.1":
+  version "10.10.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.10.1.tgz#d5c96ca246a418404914d180b7fdd625ad18eca6"
 
 agent-base@4, agent-base@^4.1.0:
   version "4.2.0"
@@ -47,7 +47,11 @@ buffer-from@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
 
-chalk@^2.3.0, chalk@^2.4.1:
+buffer-from@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+
+chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -129,9 +133,9 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.22.1:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
+moment@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
 
 ms@2.0.0:
   version "2.0.0"
@@ -141,13 +145,13 @@ node-fetch@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
-prettier@^1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.12.1.tgz#c1ad20e803e7749faf905a409d2367e06bbe7325"
+prettier@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
 
-source-map-support@^0.5.3:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+source-map-support@^0.5.6:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -162,22 +166,22 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-ts-node@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.0.3.tgz#28bf74bcad134fad17f7469dad04638ece03f0f4"
+ts-node@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
   dependencies:
     arrify "^1.0.0"
-    chalk "^2.3.0"
+    buffer-from "^1.1.0"
     diff "^3.1.0"
     make-error "^1.1.1"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    source-map-support "^0.5.3"
+    source-map-support "^0.5.6"
     yn "^2.0.0"
 
-typescript@^2.8.3:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+typescript@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 url-template@^2.0.8:
   version "2.0.8"


### PR DESCRIPTION
Looks like `@octokit/rest` added typed responses to the API, making most of the custom code unnecessary.